### PR TITLE
KT1-145: feat(reward-service): AI 리워드 생성 워커 구현 및 개인화 보상 URL UserRewar…

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,23 @@
 from fastapi import FastAPI
 from app.utils.db import engine, Base
 from app.config.config import Config
+import logging
+import sys
+import asyncio
+from confluent_kafka.admin import AdminClient, NewTopic
+from confluent_kafka import KafkaException
 
 # 모든 모델을 임포트하여 Base.metadata에 등록 (초기에는 비어있음)
 from app.models import reward, user_reward
+
+logger = logging.getLogger(__name__)
+
+# 로깅 설정
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.getLogger("uvicorn").propagate = False
+logging.getLogger("uvicorn.access").propagate = False
+logging.getLogger("uvicorn.error").propagate = False
 
 def create_app():
     app = FastAPI()
@@ -16,6 +30,56 @@ def create_app():
     # API 라우터 포함
     from app.api import reward_router
     app.include_router(reward_router.router, prefix="/api/v1", tags=["rewards"])
+
+    @app.on_event("startup")
+    async def startup_event():
+        logger.info("Application startup event triggered.")
+        
+        # Kafka 브로커 준비 대기 및 토픽 생성 로직
+        admin_client = AdminClient({'bootstrap.servers': Config.KAFKA_BROKER_URL})
+        max_retries = 60
+        retry_delay = 2
+        
+        for i in range(max_retries):
+            try:
+                metadata = admin_client.list_topics(timeout=1)
+                logger.info(f"Kafka brokers are ready: {metadata.brokers}")
+
+                topics_to_create = [Config.REWARD_GENERATION_REQUESTS_TOPIC]
+                existing_topics = metadata.topics
+                new_topics = []
+                for topic_name in topics_to_create:
+                    if topic_name not in existing_topics:
+                        logger.info(f"Topic '{topic_name}' not found. Creating it...")
+                        new_topics.append(NewTopic(topic_name, num_partitions=1, replication_factor=1))
+                    else:
+                        logger.info(f"Topic '{topic_name}' already exists.")
+                
+                if new_topics:
+                    admin_client.create_topics(new_topics)
+                    logger.info(f"Topics created successfully.")
+
+                break
+            except KafkaException as e:
+                logger.warning(f"Waiting for Kafka brokers to be ready... ({i+1}/{max_retries}) - {e}")
+                await asyncio.sleep(retry_delay)
+            except Exception as e:
+                logger.error(f"An unexpected error occurred while waiting for Kafka: {e}")
+                await asyncio.sleep(retry_delay)
+        else:
+            logger.error("Failed to connect to Kafka brokers after multiple retries. Consumer will not start.")
+            return
+
+        # AI Reward Consumer 스레드 시작
+        from app.core.ai_reward_generator import start_ai_reward_consumer
+        start_ai_reward_consumer()
+
+    @app.on_event("shutdown")
+    async def shutdown_event():
+        logger.info("Application shutdown event triggered.")
+        # 컨슈머 종료 로직 (필요시 구현)
+        # from app.core.ai_reward_generator import stop_ai_reward_consumer
+        # stop_ai_reward_consumer()
 
     @app.get("/")
     def read_root():

--- a/app/api/reward_router.py
+++ b/app/api/reward_router.py
@@ -1,10 +1,11 @@
+
 from fastapi import APIRouter, Depends, HTTPException, Body
 from sqlalchemy.orm import Session
 from app.core.kafka_producer_service import get_kafka_producer, produce_reward_generation_request
 from app.utils.db import get_db
 from app.core import crud_service
 from app import schemas # schemas 모듈 임포트 추가
-from app.schemas.reward_schema import UserReward, RewardCreate # RewardCreate 스키마 임포트 추가
+from app.schemas.reward_schema import UserReward, RewardCreate, UserRewardCreate # UserRewardCreate 스키마 임포트 추가
 from app.models.reward import RewardType
 
 router = APIRouter()
@@ -19,25 +20,49 @@ def award_reward_to_user(user_id: int, reward_id: int, db: Session = Depends(get
     return crud_service.create_user_reward(db=db, user_reward=schemas.UserRewardCreate(user_id=user_id, reward_id=reward_id))
 
 
-@router.post("/rewards/request-ai-generation")
+@router.post("/rewards/request-ai-generation", response_model=UserReward) # UserReward를 반환하도록 변경
 def request_ai_reward_generation(
     user_id: int = Body(...),
     reward_type_id: int = Body(...), # AI로 생성할 보상 유형의 ID (예: '기억의 정원 오브제'의 ID)
     generation_prompt: str = Body(...),
     db: Session = Depends(get_db)
 ):
-    db_reward_type = crud_service.get_reward(db, reward_id=reward_type_id)
+    db_reward_type = crud_service.get_reward(db, reward_type_id)
     if not db_reward_type:
         raise HTTPException(status_code=404, detail="Reward type not found")
 
     if db_reward_type.reward_type != RewardType.personalization:
         raise HTTPException(status_code=400, detail="Only personalization type rewards can be requested for AI generation.")
 
+    # 1. UserReward 레코드 조회 또는 생성
+    # 이미 해당 user_id와 reward_type_id로 UserReward가 있는지 확인
+    existing_user_reward = crud_service.get_user_reward_by_user_id_and_reward_id(db, user_id, reward_type_id)
+
+    if existing_user_reward:
+        # 이미 UserReward가 존재하면, generated_image_url이 없는 경우에만 요청을 진행
+        if existing_user_reward.generated_image_url:
+            raise HTTPException(status_code=400, detail="AI reward already generated for this user and reward type.")
+        created_user_reward = existing_user_reward
+    else:
+        # UserReward가 없으면 새로 생성
+        user_reward_data = UserRewardCreate(
+            user_id=user_id,
+            reward_id=reward_type_id, # 여기서는 Reward 유형 ID를 사용
+            position_x=None,
+            position_y=None,
+            generated_image_url=None # 초기에는 이미지 URL 없음
+        )
+        created_user_reward = crud_service.create_user_reward(db, user_reward_data)
+
+    # 2. Kafka 메시지에 created_user_reward.id 포함하여 발행
     producer = get_kafka_producer()
     produce_reward_generation_request(
         producer=producer,
         user_id=user_id,
         reward_type_id=reward_type_id,
-        generation_prompt=generation_prompt
+        generation_prompt=generation_prompt,
+        user_reward_id=created_user_reward.id # 새로 생성된 UserReward의 ID 포함
     )
-    return {"message": "AI reward generation request accepted"}
+    
+    # 생성 또는 조회된 UserReward 객체를 반환
+    return created_user_reward

--- a/app/core/ai_reward_generator.py
+++ b/app/core/ai_reward_generator.py
@@ -1,0 +1,108 @@
+import json
+import os
+import threading
+import time
+import asyncio
+import logging
+from datetime import datetime
+from confluent_kafka import Consumer, KafkaException, KafkaError
+from sqlalchemy.orm import Session
+from app.utils.db import SessionLocal
+from app.core import crud_service
+from app.config.config import Config
+from app.models.reward import RewardType
+from app.schemas.reward_schema import UserRewardCreate
+
+logger = logging.getLogger(__name__)
+
+# AI 이미지 생성 및 S3 업로드 관련 모듈 (가정)
+# 실제 구현에서는 Meshy.ai 또는 다른 AI API 연동 로직이 들어갑니다。
+# 여기서는 더미 함수로 대체합니다.
+
+def generate_ai_image(prompt: str) -> str:
+    """
+    AI 이미지 생성 API를 호출하고 이미지 URL을 반환합니다.
+    실제 구현에서는 Meshy.ai 등의 API를 사용합니다。
+    """
+    logger.info(f"[AI Image Generation] Generating image for prompt: {prompt}")
+    # 실제 이미지 생성 및 S3 업로드 로직
+    # 예시: S3에 업로드된 이미지 URL 반환
+    dummy_image_url = f"https://kibwa-17.s3.ap-southeast-1.amazonaws.com/ai-generated-rewards/dummy_{int(time.time())}.png"
+    logger.info(f"[AI Image Generation] Dummy image URL generated: {dummy_image_url}")
+    return dummy_image_url
+
+async def _process_message(msg):
+    logger.info(f"[Kafka Consumer] Attempting to process message from topic: {msg.topic()}")
+    message_value = json.loads(msg.value().decode('utf-8'))
+    user_id = message_value.get("user_id")
+    reward_type_id = message_value.get("reward_type_id")
+    generation_prompt = message_value.get("generation_prompt")
+    user_reward_id = message_value.get("user_reward_id")
+
+    logger.info(f"[Kafka Consumer] Received message: user_id={user_id}, reward_type_id={reward_type_id}, prompt='{generation_prompt}', user_reward_id={user_reward_id}")
+
+    # AI 이미지 생성
+    generated_image_url = generate_ai_image(generation_prompt)
+
+    db: Session = SessionLocal()
+    try:
+        # UserReward 레코드 조회 및 generated_image_url 업데이트
+        user_reward_entry = crud_service.get_user_reward_by_id(db, user_reward_id)
+        if user_reward_entry:
+            user_reward_entry.generated_image_url = generated_image_url
+            db.commit()
+            logger.info(f"[Kafka Consumer] Updated UserReward {user_reward_entry.id} with generated image URL: {generated_image_url}")
+        else:
+            logger.warning(f"[Kafka Consumer] UserReward with ID {user_reward_id} not found. Cannot update image URL.")
+
+    except Exception as e:
+        db.rollback()
+        logger.error(f"[Kafka Consumer] Error processing message: {e}", exc_info=True)
+    finally:
+        db.close()
+
+async def _run_consumer_loop(consumer, topics, running_flag):
+    logger.debug("[Kafka Consumer] _run_consumer_loop entered")
+    try:
+        consumer.subscribe(topics)
+        logger.info(f"[Kafka Consumer] Subscribed to topics: {topics}")
+
+        while running_flag[0]:
+            msg = consumer.poll(timeout=10.0) # timeout을 10.0초로 늘림
+            if msg is None:
+                logger.debug("[Kafka Consumer] No message received within timeout. Continuing to poll...")
+                continue
+            if msg.error():
+                if msg.error().code() == KafkaError._PARTITION_EOF:
+                    logger.debug(f"[Kafka Consumer] %% {msg.topic()} [{msg.partition()}] reached end offset {msg.offset()}")
+                else:
+                    logger.error(f"[Kafka Consumer] Kafka consumer error: {msg.error()}", exc_info=True)
+                    raise KafkaException(msg.error())
+            else:
+                await _process_message(msg)
+
+    except Exception as e:
+        logger.exception(f"[Kafka Consumer] Consumer loop encountered an error: {e}")
+    finally:
+        consumer.close()
+        logger.info("[Kafka Consumer] Consumer closed.")
+
+def start_ai_reward_consumer():
+    logger.debug("[Kafka Consumer] start_ai_reward_consumer called")
+    consumer_conf = {
+        'bootstrap.servers': Config.KAFKA_BROKER_URL,
+        'group.id': 'ai-reward-generator-group',
+        'auto.offset.reset': 'earliest'
+    }
+    consumer = Consumer(consumer_conf)
+    topic = Config.REWARD_GENERATION_REQUESTS_TOPIC
+
+    running_flag = [True]
+    consumer_thread = threading.Thread(target=lambda: asyncio.run(_run_consumer_loop(consumer, [topic], running_flag)))
+    consumer_thread.daemon = True
+    consumer_thread.start()
+    logger.info("[Kafka Consumer] AI Reward Consumer thread started.")
+
+def stop_ai_reward_consumer():
+    # 이 함수는 현재 사용되지 않지만, 컨슈머를 안전하게 종료하기 위해 필요합니다。
+    pass

--- a/app/core/crud_service.py
+++ b/app/core/crud_service.py
@@ -64,6 +64,9 @@ def get_user_rewards(db: Session, user_id: int) -> List[models.UserReward]:
 def get_user_reward_by_id(db: Session, user_reward_id: int) -> Optional[models.UserReward]:
     return db.query(models.UserReward).filter(models.UserReward.id == user_reward_id).first()
 
+def get_user_reward_by_user_id_and_reward_id(db: Session, user_id: int, reward_id: int) -> Optional[models.UserReward]:
+    return db.query(models.UserReward).filter(models.UserReward.user_id == user_id, models.UserReward.reward_id == reward_id).first()
+
 def update_user_reward_position(db: Session, user_reward_id: int, position_x: Optional[int], position_y: Optional[int]) -> Optional[models.UserReward]:
     db_user_reward = db.query(models.UserReward).filter(models.UserReward.id == user_reward_id).first()
     if db_user_reward:

--- a/app/core/kafka_producer_service.py
+++ b/app/core/kafka_producer_service.py
@@ -5,12 +5,13 @@ from app.config.config import Config
 def get_kafka_producer():
     return Producer({'bootstrap.servers': Config.KAFKA_BROKER_URL})
 
-def produce_reward_generation_request(producer: Producer, user_id: int, reward_type_id: int, generation_prompt: str):
+def produce_reward_generation_request(producer: Producer, user_id: int, reward_type_id: int, generation_prompt: str, user_reward_id: int):
     topic = "reward-generation-requests"
     message = {
         "user_id": user_id,
         "reward_type_id": reward_type_id,
         "generation_prompt": generation_prompt,
+        "user_reward_id": user_reward_id,
     }
     producer.produce(topic, key=str(user_id), value=json.dumps(message))
     producer.flush()

--- a/app/models/user_reward.py
+++ b/app/models/user_reward.py
@@ -11,6 +11,7 @@ class UserReward(Base):
     acquired_at = Column(DateTime, server_default=func.now())
     position_x = Column(Integer, nullable=True) # 정원 내 배치 X 좌표
     position_y = Column(Integer, nullable=True) # 정원 내 배치 Y 좌표
+    generated_image_url = Column(String, nullable=True) # AI 생성 이미지 URL (개인화 보상용)
 
     # 한 사용자는 같은 리워드를 한 번만 획득할 수 있도록 UniqueConstraint 추가
     __table_args__ = (UniqueConstraint('user_id', 'reward_id', name='_user_reward_uc'),)

--- a/app/schemas/reward_schema.py
+++ b/app/schemas/reward_schema.py
@@ -30,6 +30,7 @@ class UserRewardBase(BaseModel):
     reward_id: int
     position_x: Optional[int] = None
     position_y: Optional[int] = None
+    generated_image_url: Optional[str] = None # AI 생성 이미지 URL (개인화 보상용)
 
 class UserRewardCreate(UserRewardBase):
     pass


### PR DESCRIPTION
…d에 저장

- AI 리워드 생성 워커 (Kafka Consumer) 로직 구현 (app/core/ai_reward_generator.py)
- 개인화 보상 이미지 URL을 UserReward 모델의 generated_image_url 필드에 저장하도록 변경
- request-ai-generation 엔드포인트에서 UserReward를 먼저 생성하고 ID를 Kafka 메시지에 포함
- Kafka Producer가 user_reward_id를 메시지에 포함하도록 수정
- UserReward 모델 및 스키마에 generated_image_url 필드 반영